### PR TITLE
reuse original response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Results are not cached. If you need caching, use a caching middleware. This is j
 ## Features
 
 - Respond to multiple identical requests with results from first request
-- User specific session key for cache key
+- User-specific session key for cache key
 
 ## Todo
 
 - [ ] Improve readme file (install notes, build status, coverage?)
-- [ ] Check if there are some cases that are no covered, eg. different responese statuses, headers, body types, etc.
+- [ ] Check if there are some cases that are not covered, eg. different responese statuses, headers, body types, etc.
 - [ ] Add tests for different body types
 - [ ] Add tests for different response statuses
 - [ ] Add tests for different response headers

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 # Request Cool-Down for Fastify and Koa
 
-Call route handler once for all parallel requests
+Handle all parallel requests once for identical requests.
+It doesn't cache results - it caches request promise and uses results to serve all identical requests.
+Result is not cached, if you need that use caching middleware. This is just plane simple tool for solving request burst to long running expensive requests that could happen by reloading dozen of browser tabs or abbusing page reload.
 
 ## Features
 
-- Respond to multiple equivalent requests with results from first request
-- Use user speciffic sessions
+- Respond to multiple identical requests with results from first request
+- User speciffic session key for cache key
 
 ## Todo
 
-- [ ] Tests for koa
 - [ ] Improve readme file (install notes, build status, coverage?)
-- [ ] Hono
+- [ ] Check if there are some cases that are no covered, eg. different responese statuses, headers, body types, etc.
+- [ ] Add tests for different body types
+- [ ] Add tests for different response statuses
+- [ ] Add tests for different response headers
+- [ ] Add tests for different response body types
+- [ ] Add tests for different response body types

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Results are not cached. If you need caching, use a caching middleware. This is j
 - Respond to multiple identical requests with results from first request
 - User-specific session key for cache key
 
-## Todo
+## To-Do
 
 - [ ] Improve readme file (install notes, build status, coverage?)
 - [ ] Check if there are some cases that are not covered, eg. different responese statuses, headers, body types, etc.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Request Cool-Down for Fastify and Koa
 
-Handle all parallel requests once for identical requests.
-It doesn't cache results - it caches request promise and uses results to serve all identical requests.
-Result is not cached, if you need that use caching middleware. This is just plane simple tool for solving request burst to long running expensive requests that could happen by reloading dozen of browser tabs or abbusing page reload.
+Handles all parallel requests once for identical requests.
+It doesn't cache results - it caches the request promise and uses the results to serve all identical requests.
+Results are not cached. If you need caching, use a caching middleware. This is just a plain and simple tool for solving request bursts to long-running expensive requests that could happen by reloading dozens of browser tabs or abusing page reload.
 
 ## Features
 
 - Respond to multiple identical requests with results from first request
-- User speciffic session key for cache key
+- User specific session key for cache key
 
 ## Todo
 
@@ -16,5 +16,4 @@ Result is not cached, if you need that use caching middleware. This is just plan
 - [ ] Add tests for different body types
 - [ ] Add tests for different response statuses
 - [ ] Add tests for different response headers
-- [ ] Add tests for different response body types
 - [ ] Add tests for different response body types

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
   },
   "packageManager": "pnpm@9.5.0",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,4 @@
 export const DEFAULT_METHODS = ['GET', 'HEAD']
 export const DEFAULT_TIMEOUT = 60_000
+
+export const REQ_BODY_METHODS = ['POST', 'PUT', 'PATCH']

--- a/src/fastify/plugin.ts
+++ b/src/fastify/plugin.ts
@@ -1,7 +1,11 @@
 import fastifyPlugin from 'fastify-plugin'
 
 import type { FastifyCoolDownProps } from './types'
-import { DEFAULT_METHODS, DEFAULT_TIMEOUT } from '../constants'
+import {
+  DEFAULT_METHODS,
+  DEFAULT_TIMEOUT,
+  REQ_BODY_METHODS,
+} from '../constants'
 import type { ResolveResponse, StoreEntry } from '../types'
 
 const defaultOptions = {
@@ -32,7 +36,10 @@ export const fastifyCoolDown = fastifyPlugin<FastifyCoolDownProps>(
           user: options.getUserKey?.(req) ?? req.ip,
           method: req.method,
           url: req.originalUrl,
-          body: req.body,
+          // TODO Handle streams
+          body: REQ_BODY_METHODS.includes(req.method.toUpperCase())
+            ? req.body
+            : undefined,
         })
 
       const cached = promiseStore[key]
@@ -91,15 +98,16 @@ export const fastifyCoolDown = fastifyPlugin<FastifyCoolDownProps>(
         if (options.onBadReply)
           return options.onBadReply(req, reply, result.badReply, done)
 
+        reply.headers(result.badReply.headers)
         reply.header('Content-Type', result.badReply.type)
         reply.status(result.badReply.statusCode)
         reply.send(result.badReply.payload)
         return
       }
 
+      reply.headers(result.headers)
       reply.header('Content-Type', result.type)
       reply.header('Last-Modified', result.lastModified)
-      reply.header('etag', result.etag)
       reply.send(result.payload)
 
       logger?.debug({ coolReqId: cached.reqId }, 'Cool response')
@@ -114,21 +122,22 @@ export const fastifyCoolDown = fastifyPlugin<FastifyCoolDownProps>(
             )
           : undefined
 
-      if (reply.statusCode !== 200) {
+      if (reply.statusCode < 200 || reply.statusCode >= 300) {
         return req.reqCooldownResolve?.({
           badReply: {
             statusCode: reply.statusCode,
             payload: payload,
-            type: reply.getHeader('Content-Type') || null,
+            type: reply.getHeader('Content-Type') ?? null,
+            headers: reply.getHeaders(),
           },
         })
       }
 
       req.reqCooldownResolve?.({
         payload: payload,
-        type: reply.getHeader('Content-Type') || null,
-        lastModified: reply.getHeader('Last-Modified') || null,
-        etag: reply.getHeader('etag') || null,
+        type: reply.getHeader('Content-Type') ?? null,
+        lastModified: reply.getHeader('Last-Modified') ?? null,
+        headers: reply.getHeaders(),
       })
 
       if (req.reqCooldownTimedOut) {

--- a/src/fastify/types.ts
+++ b/src/fastify/types.ts
@@ -1,12 +1,14 @@
 import type { FastifyReply } from 'fastify/types/reply'
 import type { FastifyRequest } from 'fastify/types/request'
 
-import type { AccessPluginOptions, BadReply, ResolveResponse } from '../types'
+import type {
+  AccessPluginOptions,
+  BadReply,
+  ReqCooldownResolver,
+} from '../types'
 
 type CoolDownContext = {
-  reqCooldownResolve?: (
-    value: ResolveResponse | PromiseLike<ResolveResponse>
-  ) => void
+  reqCooldownResolve?: ReqCooldownResolver
   reqCooldownTimedOut?: boolean
 }
 

--- a/src/koa/middleware.ts
+++ b/src/koa/middleware.ts
@@ -1,8 +1,12 @@
 import type { Middleware } from 'koa'
 
-import type { KoaCoolDownProps } from './types'
-import { DEFAULT_METHODS, DEFAULT_TIMEOUT } from '../constants'
-import type { ResolveResponse, StoreEntry } from '../types'
+import { getHeaderValue, type KoaCoolDownProps } from './types'
+import {
+  DEFAULT_METHODS,
+  DEFAULT_TIMEOUT,
+  REQ_BODY_METHODS,
+} from '../constants'
+import type { ReqCooldownResolver, ResolveResponse, StoreEntry } from '../types'
 
 const defaultOptions = {
   methods: DEFAULT_METHODS,
@@ -38,16 +42,17 @@ export function koaCoolDown<StateT = unknown, CustomT extends object = object>(
         user: options?.getUserKey?.(ctx) ?? ctx.ip,
         method: ctx.method,
         url: ctx.url,
-        body: ctx.request.body,
+        // TODO Handle streams
+        body: REQ_BODY_METHODS.includes(ctx.method.toUpperCase())
+          ? ctx.request.body
+          : undefined,
       })
 
     const cached = promiseStore[key]
 
     if (!cached) {
       let reqCooldownTimedOut = false
-      let reqCooldownResolve: (
-        value: ResolveResponse | PromiseLike<ResolveResponse>
-      ) => void = () => {}
+      let reqCooldownResolve: ReqCooldownResolver = () => {}
 
       const cached: Omit<StoreEntry, 'coolDown'> & {
         coolDown?: StoreEntry['coolDown']
@@ -85,20 +90,21 @@ export function koaCoolDown<StateT = unknown, CustomT extends object = object>(
         await next()
 
         // Handle response
-        if (ctx.status !== 200) {
+        if (ctx.status < 200 || ctx.status >= 300) {
           reqCooldownResolve({
             badReply: {
               statusCode: ctx.status,
               payload: ctx.body,
-              type: ctx.response.get('Content-Type') || null,
+              type: ctx.response.get('Content-Type') ?? null,
+              headers: ctx.response.headers,
             },
           })
         } else {
           reqCooldownResolve({
             payload: ctx.body,
-            type: ctx.response.get('Content-Type') || null,
-            lastModified: ctx.response.get('Last-Modified') || null,
-            etag: ctx.response.get('etag') || null,
+            type: ctx.response.get('Content-Type') ?? null,
+            lastModified: ctx.response.get('Last-Modified') ?? null,
+            headers: ctx.response.headers,
           })
         }
 
@@ -112,6 +118,7 @@ export function koaCoolDown<StateT = unknown, CustomT extends object = object>(
             statusCode: 500,
             payload: { error: message },
             type: 'application/json',
+            headers: ctx.response.headers,
           },
         })
         throw error
@@ -135,6 +142,15 @@ export function koaCoolDown<StateT = unknown, CustomT extends object = object>(
       if (options?.onBadReply)
         return options.onBadReply(ctx, result.badReply, next)
 
+      for (const [key, value] of Object.entries(result.badReply.headers)) {
+        if (value === undefined) continue
+        if (Array.isArray(value)) {
+          for (const v of value) ctx.set(key, v)
+          continue
+        }
+        ctx.set(key, `${value}`)
+      }
+
       ctx.status = result.badReply.statusCode
       if (result.badReply.type)
         ctx.set(
@@ -147,23 +163,19 @@ export function koaCoolDown<StateT = unknown, CustomT extends object = object>(
       return
     }
 
-    if (result.type)
-      ctx.set(
-        'Content-Type',
-        typeof result.type === 'number' ? String(result.type) : result.type
-      )
+    for (const [key, value] of Object.entries(result.headers)) {
+      if (value === undefined) continue
+      if (Array.isArray(value)) {
+        for (const v of value) ctx.set(key, v)
+        continue
+      }
+      ctx.set(key, `${value}`)
+    }
+
+    if (result.type) ctx.set('Content-Type', getHeaderValue(result.type))
     if (result.lastModified)
-      ctx.set(
-        'Last-Modified',
-        typeof result.lastModified === 'number'
-          ? String(result.lastModified)
-          : result.lastModified
-      )
-    if (result.etag)
-      ctx.set(
-        'etag',
-        typeof result.etag === 'number' ? String(result.etag) : result.etag
-      )
+      ctx.set('Last-Modified', getHeaderValue(result.lastModified))
+
     ctx.body = result.payload
 
     logger.debug({ coolReqId: cached.reqId }, 'Cool response')

--- a/src/koa/middleware.ts
+++ b/src/koa/middleware.ts
@@ -52,7 +52,9 @@ export function koaCoolDown<StateT = unknown, CustomT extends object = object>(
 
     if (!cached) {
       let reqCooldownTimedOut = false
-      let reqCooldownResolve: ReqCooldownResolver = () => {}
+      let reqCooldownResolve: ReqCooldownResolver = () => {
+        throw new Error('Request Cool-Down promise not initialized')
+      }
 
       const cached: Omit<StoreEntry, 'coolDown'> & {
         coolDown?: StoreEntry['coolDown']

--- a/src/koa/types.ts
+++ b/src/koa/types.ts
@@ -26,3 +26,6 @@ export type KoaCoolDownProps<
   getRequestId?: (context: ParameterizedContext<StateT, CustomT>) => string
   logger?: Logger | ((context: ParameterizedContext<StateT, CustomT>) => Logger)
 }
+
+export const getHeaderValue = (value?: string | number | string[]) =>
+  typeof value === 'number' ? String(value) : value ?? ''

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,10 +4,15 @@ export type StoreEntry = {
   coolDown: Promise<ResolveResponse>
 }
 
+export type ReqCooldownResolver = (
+  value: ResolveResponse | Promise<ResolveResponse>
+) => void
+
 export type BadReply = {
   statusCode: number
   payload: unknown
   type?: string | string[] | number | null
+  headers: Record<string, number | string | string[] | undefined>
 }
 
 export type ResolveResponse =
@@ -15,7 +20,7 @@ export type ResolveResponse =
       payload: unknown
       type?: string | string[] | number | null
       lastModified?: string | string[] | number | null
-      etag?: string | string[] | number | null
+      headers: Record<string, number | string | string[] | undefined>
     }
   | {
       badReply: BadReply

--- a/tests/fastify.test.ts
+++ b/tests/fastify.test.ts
@@ -59,8 +59,11 @@ describe('fastify', async () => {
 
     if (assertionError.error) throw assertionError.error
     expect(response1.body).toEqual('1')
+    expect(response1.headers['x-request-id']).toEqual('1')
     expect(response2.body).toEqual('2')
+    expect(response2.headers['x-request-id']).toEqual('2')
     expect(response22.body).toEqual('2')
+    expect(response22.headers['x-request-id']).toEqual('2')
   })
 
   it('requests promise should be only cached while it is in progress', async () => {

--- a/tests/koa.test.ts
+++ b/tests/koa.test.ts
@@ -28,8 +28,11 @@ describe('koa', async () => {
 
     if (assertionError.error) throw assertionError.error
     expect(response1.text).toEqual('1')
+    expect(response1.headers['x-request-id']).toEqual('1')
     expect(response2.text).toEqual('2')
+    expect(response2.headers['x-request-id']).toEqual('2')
     expect(response22.text).toEqual('2')
+    expect(response22.headers['x-request-id']).toEqual('2')
     server.close()
   })
 

--- a/tests/utils/fastify.ts
+++ b/tests/utils/fastify.ts
@@ -9,7 +9,7 @@ import { sleep } from './general'
 import { fastifyCoolDown } from '../../src'
 import type { FastifyCoolDownProps } from '../../src/fastify/types'
 
-export const REQUEST_DELAY = 10
+export const REQUEST_DELAY = 20
 
 export const getApp = async (props?: FastifyCoolDownProps) => {
   const assertionError: { error?: Error | undefined } = {}
@@ -55,6 +55,7 @@ export const getRequestHandler =
       return
     }
 
+    reply.header('x-request-id', request.headers['x-request-id'])
     reply.send(request.headers['x-request-id'])
   }
 

--- a/tests/utils/koa.ts
+++ b/tests/utils/koa.ts
@@ -51,6 +51,7 @@ export const getRequestHandler =
       return
     }
 
+    ctx.set('x-request-id', `${ctx.request.header['x-request-id']}`)
     ctx.body = ctx.request.header['x-request-id']
   }
 


### PR DESCRIPTION
Use headers from original response in cached response.
Fix some bugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**  
  - Clarified the request handling mechanism and caching strategy in the project guide.

- **New Features**  
  - Enhanced request processing logic to conditionally include request data for improved caching.
  - Improved response header consistency, ensuring reliable propagation of request identifiers.
  - Introduced a new function to standardize header value retrieval.

- **Bug Fixes**  
  - Enhanced test coverage for the `x-request-id` header in both Fastify and Koa test suites.

- **Chores**  
  - Raised the minimum Node.js requirement to version 18.  
  - Increased the request delay duration in test utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->